### PR TITLE
Allow set CurlLite option to Null

### DIFF
--- a/google/appengine/runtime/CurlLite.php
+++ b/google/appengine/runtime/CurlLite.php
@@ -484,9 +484,10 @@ final class CurlLite {
       case CURLOPT_QUOTE:
       case CURLOPT_PROGRESSFUNCTION:
       case CURLOPT_SHARE:
-        throw new CurlLiteOptionNotSupportedException(
-          'Option ' . $key . ' is not supported by this curl implementation.');
-
+        if ($value !== null) {
+          throw new CurlLiteOptionNotSupportedException(
+            'Option ' . $key . ' is not supported by this curl implementation.');
+        }
       // Everything else is a no-op, or will be configured at request time.
       default:
     }


### PR DESCRIPTION
Even if option not supported we can allow set it to Null. 
It required for compatibility with [Guzzle library](https://github.com/guzzle/guzzle/blob/master/src/Handler/CurlFactory.php#L77) .
